### PR TITLE
Fix test DB setup & configure ts-jest

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -2,6 +2,11 @@ import type { Config } from 'jest';
 
 const config: Config = {
   preset: 'ts-jest',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json',
+    },
+  },
   testEnvironment: 'node',
   testTimeout: 10000,
   roots: ['<rootDir>/tests', '<rootDir>/__tests__'],

--- a/backend/scripts/create-test-db.ts
+++ b/backend/scripts/create-test-db.ts
@@ -37,9 +37,9 @@ export async function createTestDb(retries = 5): Promise<void> {
   await client.query(publicSql);
 
   await client.query(
-    `INSERT INTO public.plans (id, name, config_json)
+    `INSERT INTO public.plans (id, name, features)
      VALUES ($1, $2, $3)`,
-    [randomUUID(), 'basic', '{}']
+    [randomUUID(), 'basic', '[]']
   );
 
   await client.end();

--- a/backend/tsconfig.jest.json
+++ b/backend/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*", "__tests__/**/*"]
+}


### PR DESCRIPTION
## Summary
- fix test DB creation script to align with current schema
- add tsconfig for Jest and configure ts-jest

## Testing
- `npm test` *(fails: some suites fail due to missing types and runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_68696bf1d9d88320a70f0dd2e617759e