### PR TITLE
Add db start helper for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,3 +256,14 @@ All notable changes to this project will be documented in this file.
 
 ### Documentation
 - Logged step file `STEP_audit_20260712_COMMAND.md`.
+
+## [2026-07-13] - Automated DB Start for Tests
+
+### Added
+- `start-db-and-test.ts` helper to ensure the dev database is running before Jest.
+
+### Changed
+- Backend `test` script now invokes this helper.
+
+### Documentation
+- Logged step file `STEP_fix_20260713_COMMAND.md`.

--- a/backend/docs/LOCAL_DEV_SETUP.md
+++ b/backend/docs/LOCAL_DEV_SETUP.md
@@ -60,7 +60,7 @@ credentials to authenticate and test routes.
 
 ## 5. Run Unit Tests
 
-Install dependencies and execute the Jest test suites. **Start PostgreSQL first** using `./scripts/start-dev-db.sh` (Docker) or `sudo service postgresql start` if installed locally. Jest's global setup will then create and seed the `fuelsync_test` database automatically.
+Install dependencies and execute the Jest test suites. The `npm test` command will automatically launch the Docker database if it isn't running and wait for a connection before invoking Jest.
 
 ```bash
 npm install
@@ -68,5 +68,4 @@ npm test
 ```
 
 All tests should pass if the local database is configured correctly.
-If you see `Skipping tests: unable to provision test DB`, make sure PostgreSQL is
-installed or start the dev database container and run the tests again.
+If you see `Skipping tests: unable to provision test DB`, ensure Docker is installed or that PostgreSQL is running locally before retrying `npm test`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "setup-azure-db": "node scripts/setup-azure-db.js",
     "azure-migrate-cash": "node scripts/apply-cash-reports-azure.js",
     "azure-migrate-settings": "node scripts/apply-tenant-settings-kv-azure.js",
-    "test": "jest -c jest.config.ts",
+    "test": "ts-node scripts/start-db-and-test.ts",
+    "test:unit": "jest -c jest.config.ts",
     "postinstall": "prisma generate"
   },
   "dependencies": {

--- a/backend/scripts/start-db-and-test.ts
+++ b/backend/scripts/start-db-and-test.ts
@@ -1,0 +1,34 @@
+import { spawnSync, execSync } from 'child_process';
+import path from 'path';
+
+function checkConnection(): boolean {
+  const result = spawnSync('node', [path.join(__dirname, 'check-db-connection.js')], { encoding: 'utf8' });
+  return result.stdout.includes('Successfully connected');
+}
+
+async function waitForConnection(retries = 10, delayMs = 3000): Promise<boolean> {
+  for (let i = 0; i < retries; i++) {
+    if (checkConnection()) return true;
+    await new Promise(res => setTimeout(res, delayMs));
+  }
+  return false;
+}
+
+async function main() {
+  if (!checkConnection()) {
+    console.log('Database not running. Starting dev DB...');
+    execSync(`sh ${path.join(__dirname, 'start-dev-db.sh')}`, { stdio: 'inherit' });
+    const ready = await waitForConnection();
+    if (!ready) {
+      console.error('Database failed to start.');
+      process.exit(1);
+    }
+  }
+
+  execSync('npm run test:unit', { stdio: 'inherit' });
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/docs/STEP_fix_20260713_COMMAND.md
+++ b/docs/STEP_fix_20260713_COMMAND.md
@@ -1,0 +1,2 @@
+Project Context: FuelSync backend tests require a running Postgres container. Prior step 2026-07-12 performed a backend–frontend sync audit.
+Task: Create `backend/scripts/start-db-and-test.ts` to automatically start the dev database when it isn't running, wait until `check-db-connection.js` succeeds, then execute Jest. Update `backend/package.json` to run this script for `npm test`. Document the workflow in LOCAL_DEV_SETUP.md, PHASE_3_SUMMARY.md, CHANGELOGs and add the step to IMPLEMENTATION_INDEX.

--- a/docs/backend/CHANGELOG.md
+++ b/docs/backend/CHANGELOG.md
@@ -3141,3 +3141,10 @@ Each entry is tied to a step from the implementation index.
 - Removed outdated `docs/openapi/openapi.yaml`
 - Updated docs to reference `docs/openapi-spec.yaml`
 - Logged step file `STEP_fix_20260420_COMMAND.md`
+
+## [Fix 2026-07-13] – Automated DB Start for Tests
+
+### 🟢 Enhancements
+- Added `start-db-and-test.ts` to start the dev database if needed and run Jest.
+- Updated `package.json` test script to use the helper.
+- Documented step file `STEP_fix_20260713_COMMAND.md`.

--- a/docs/backend/IMPLEMENTATION_INDEX.md
+++ b/docs/backend/IMPLEMENTATION_INDEX.md
@@ -276,3 +276,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-10 | API route tests attempt 2 | ✅ Done | `docs/QA_API_TEST_REPORT_20260710.md` | `docs/STEP_fix_20260710_COMMAND.md` |
 | fix | 2026-07-11 | API route tests attempt 3 | ✅ Done | `docs/QA_API_TEST_REPORT_20260711.md` | `docs/STEP_fix_20260711_COMMAND.md` |
 | audit | 2026-07-12 | Backend–frontend sync audit | ✅ Done | `docs/FRONTEND_BACKEND_SYNC_AUDIT_20260712.md`, `backend/__tests__/integration/openapiRoutes.test.ts` | `docs/STEP_audit_20260712_COMMAND.md` |
+| fix | 2026-07-13 | Automated DB start for tests | ✅ Done | `backend/scripts/start-db-and-test.ts`, `backend/package.json` | `docs/STEP_fix_20260713_COMMAND.md` |

--- a/docs/backend/PHASE_3_SUMMARY.md
+++ b/docs/backend/PHASE_3_SUMMARY.md
@@ -395,3 +395,13 @@ Integrated latest fuel prices widget on the Owner dashboard and fixed missing fi
 - No missing integrations found; response shapes align.
 - Added automated integration tests to ensure documented GET endpoints respond.
 - Documented audit results in the new report.
+
+### 🛠️ Fix 2026-07-13 – Automated DB Start for Tests
+
+**Status:** ✅ Done
+**Files:** `backend/scripts/start-db-and-test.ts`, `backend/package.json`
+
+**Overview:**
+- Added helper script that starts the dev Postgres container when needed and waits for a successful connection.
+- Updated the backend `test` npm script to run this helper before executing Jest.
+- Updated local dev docs and phase summary accordingly.


### PR DESCRIPTION
## Summary
- add `start-db-and-test.ts` to spin up the dev DB before running Jest
- call the helper from `npm test`
- document updated workflow
- log new step and changelog entries

## Testing
- `npm install` *(passed)*
- `npm test` *(failed: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_686987244d748320ad10c4db37a98c47