### PR TITLE
Fix pump sidebar listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,3 +284,11 @@ All notable changes to this project will be documented in this file.
 
 ### Documentation
 - Added `STEP_fix_20260714_COMMAND.md` with instructions to rerun tests after initializing the database via `backend/docs/LOCAL_DEV_SETUP.md`.
+
+## [Fix 2026-07-15] - Show all pumps by default
+
+### Changed
+- `usePumps` hook now fetches all pumps when no station is selected.
+
+### Documentation
+- Logged step file `STEP_fix_20260715_COMMAND.md`.

--- a/backend/docs/IMPLEMENTATION_INDEX.md
+++ b/backend/docs/IMPLEMENTATION_INDEX.md
@@ -250,3 +250,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | audit | 2026-07-12 | Backend–frontend sync audit | ✅ Done | `docs/FRONTEND_BACKEND_SYNC_AUDIT_20260712.md`, `backend/__tests__/integration/openapiRoutes.test.ts` | `docs/STEP_audit_20260712_COMMAND.md` |
 | fix | 2026-07-13 | Shared API types & validation | ✅ Done | `shared/apiTypes.ts`, `backend/__tests__/integration/api-contract.test.ts`, `src/api/client.ts`, `src/api/fuel-inventory.ts` | `docs/STEP_fix_20260713_COMMAND.md` |
 | fix | 2026-07-14 | Test DB setup fallback | ✅ Done | `docs/STEP_fix_20260714_COMMAND.md` |
+| fix | 2026-07-15 | Pumps listing default | ✅ Done | `src/hooks/api/usePumps.ts` | `docs/STEP_fix_20260715_COMMAND.md` |

--- a/docs/STEP_fix_20260715_COMMAND.md
+++ b/docs/STEP_fix_20260715_COMMAND.md
@@ -1,0 +1,7 @@
+Project Context Summary: The PumpsPage uses `usePumps()` to fetch pump data. When opening "/dashboard/pumps" from the sidebar, no stationId is provided. The existing hook disables the query when stationId is undefined, so the page shows no pumps. Previous steps up to STEP_fix_20260714_COMMAND.md covered integration tests and documentation updates.
+
+Steps already implemented: All backend and frontend integration up to STEP_fix_20260714_COMMAND.md. Pump listing UI already exists in `src/pages/dashboard/PumpsPage.tsx`.
+
+Task: Modify `src/hooks/api/usePumps.ts` so that the pumps query runs even when no station is selected. Use a stable query key for the "all pumps" case and remove the `enabled` condition. Update docs to log this fix.
+
+Required documentation updates: `CHANGELOG.md`, `backend/docs/IMPLEMENTATION_INDEX.md`, `docs/backend/PHASE_3_SUMMARY.md`.

--- a/docs/backend/CHANGELOG.md
+++ b/docs/backend/CHANGELOG.md
@@ -3160,3 +3160,9 @@ Each entry is tied to a step from the implementation index.
 
 ### 🟢 Enhancements
 - Added documentation step `STEP_fix_20260714_COMMAND.md` outlining database setup troubleshooting for tests.
+
+## [Fix 2026-07-15] – Pumps listing default
+
+### 🟢 Enhancements
+- `usePumps` hook now loads all pumps when no station is specified.
+- Documented in `STEP_fix_20260715_COMMAND.md`.

--- a/docs/backend/PHASE_3_SUMMARY.md
+++ b/docs/backend/PHASE_3_SUMMARY.md
@@ -423,3 +423,12 @@ Integrated latest fuel prices widget on the Owner dashboard and fixed missing fi
 
 **Overview:**
 - Documented fallback instructions referencing `backend/docs/LOCAL_DEV_SETUP.md` when Jest reports `unable to provision test DB`.
+
+### 🛠️ Fix 2026-07-15 – Pumps listing default
+
+**Status:** ✅ Done
+**Files:** `src/hooks/api/usePumps.ts`
+
+**Overview:**
+- Pump listing hook now fetches all pumps when no station is selected, fixing sidebar "All Pumps" view.
+- Documented in `STEP_fix_20260715_COMMAND.md`.

--- a/src/hooks/api/usePumps.ts
+++ b/src/hooks/api/usePumps.ts
@@ -12,9 +12,8 @@ import { pumpsService, Pump, CreatePumpRequest, UpdatePumpRequest } from '@/api/
  */
 export const usePumps = (stationId?: string) => {
   return useQuery({
-    queryKey: ['pumps', stationId],
+    queryKey: ['pumps', stationId ?? 'all'],
     queryFn: () => pumpsService.getPumps(stationId),
-    enabled: stationId !== undefined,
     staleTime: 60000, // 1 minute
   });
 };


### PR DESCRIPTION
## Summary
- ensure `usePumps` runs without a station id
- document fix in changelog and phase summary
- log step in IMPLEMENTATION_INDEX

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698f2fb9808320925cb1aa169bdc31