### PR TITLE
Fix cash report API path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,3 +292,11 @@ All notable changes to this project will be documented in this file.
 
 ### Documentation
 - Logged step file `STEP_fix_20260715_COMMAND.md`.
+
+## [Fix 2026-07-16] - Cash report submission path
+
+### Changed
+- `createCashReport` in `attendant.service.ts` now posts to `/attendant/cash-report`.
+
+### Documentation
+- Logged step file `STEP_fix_20260716_COMMAND.md`.

--- a/docs/STEP_fix_20260716_COMMAND.md
+++ b/docs/STEP_fix_20260716_COMMAND.md
@@ -1,0 +1,10 @@
+# STEP_fix_20260716_COMMAND.md — Cash report submission path
+
+Project Context Summary:
+FuelSync Hub is a multi-tenant SaaS ERP for fuel stations. Recent fixes up to `STEP_fix_20260715_COMMAND.md` covered frontend hook updates. Attendant cash report submissions are failing because the frontend service posts to `/attendant/cash-reports` while the backend expects `/attendant/cash-report` as per the OpenAPI spec.
+
+Steps already implemented: All backend and frontend features up to `STEP_fix_20260715_COMMAND.md` with documentation updates.
+
+Task: Align the contract-based API client with the backend route. Update `src/api/contract/attendant.service.ts` so `createCashReport` sends POST requests to `/attendant/cash-report`. Document this fix.
+
+Required documentation updates: `CHANGELOG.md`, `docs/backend/IMPLEMENTATION_INDEX.md`, `docs/backend/PHASE_3_SUMMARY.md`.

--- a/docs/backend/IMPLEMENTATION_INDEX.md
+++ b/docs/backend/IMPLEMENTATION_INDEX.md
@@ -279,3 +279,5 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-13 | Automated DB start for tests | ✅ Done | `backend/scripts/start-db-and-test.ts`, `backend/package.json` | `docs/STEP_fix_20260713_COMMAND.md` |
 | fix | 2026-07-13 | Shared API types & validation | ✅ Done | `shared/apiTypes.ts`, `backend/__tests__/integration/api-contract.test.ts`, `src/api/client.ts`, `src/api/fuel-inventory.ts` | `docs/STEP_fix_20260713_COMMAND.md` |
 | fix | 2026-07-14 | Test DB setup fallback | ✅ Done | `docs/STEP_fix_20260714_COMMAND.md` |
+| fix | 2026-07-15 | Pumps listing default | ✅ Done | `src/hooks/api/usePumps.ts` | `docs/STEP_fix_20260715_COMMAND.md` |
+| fix | 2026-07-16 | Cash report path fix | ✅ Done | `src/api/contract/attendant.service.ts` | `docs/STEP_fix_20260716_COMMAND.md` |

--- a/docs/backend/PHASE_3_SUMMARY.md
+++ b/docs/backend/PHASE_3_SUMMARY.md
@@ -432,3 +432,12 @@ Integrated latest fuel prices widget on the Owner dashboard and fixed missing fi
 **Overview:**
 - Pump listing hook now fetches all pumps when no station is selected, fixing sidebar "All Pumps" view.
 - Documented in `STEP_fix_20260715_COMMAND.md`.
+
+### 🛠️ Fix 2026-07-16 – Cash report submission path
+
+**Status:** ✅ Done
+**Files:** `src/api/contract/attendant.service.ts`
+
+**Overview:**
+- `createCashReport` now targets `/attendant/cash-report` to match backend routes.
+- Documented in `STEP_fix_20260716_COMMAND.md`.

--- a/src/api/contract/attendant.service.ts
+++ b/src/api/contract/attendant.service.ts
@@ -54,10 +54,10 @@ export class AttendantService {
 
   /**
    * Submit cash report
-   * POST /attendant/cash-reports
+   * POST /attendant/cash-report
    */
   async createCashReport(data: CreateCashReportRequest): Promise<CashReport> {
-    return contractClient.post<CashReport>('/attendant/cash-reports', data);
+    return contractClient.post<CashReport>('/attendant/cash-report', data);
   }
 
   /**


### PR DESCRIPTION
## Summary
- point `createCashReport` to `/attendant/cash-report`
- document fix

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869919b3e0c8320a127ac24975476cb