### PR TITLE
Fix reading log metadata display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,3 +341,9 @@ All notable changes to this project will be documented in this file.
 
 ### Documentation
 - Logged step file `docs/backend/STEP_3_16_COMMAND.md`
+
+## [Fix 2026-07-20] - Reading card metadata
+
+### Changed
+- Daily Reading Log cards now display pump name with nozzle number and show who recorded the reading.
+- Documented in `STEP_fix_20260720_COMMAND.md`.

--- a/docs/STEP_fix_20260720_COMMAND.md
+++ b/docs/STEP_fix_20260720_COMMAND.md
@@ -1,0 +1,10 @@
+# STEP_fix_20260720_COMMAND.md — Display nozzle number and recorder
+
+Project Context Summary:
+Daily Reading Log cards showed pump name but omitted nozzle number and the attendant name, confusing station managers. Backend `/v1/nozzle-readings` already returns `nozzle_number` and `recorded_by` but the UI header didn't display them.
+
+Steps already implemented: All fixes through `STEP_fix_20260719_COMMAND.md` including lint cleanup and local DB docs.
+
+Task: Verify API and React Query hooks expose `nozzleNumber` and `recordedBy`. Update `ReadingReceiptCard` to combine pump name and nozzle number in the header and display the recorder. Document changes.
+
+Required documentation updates: `CHANGELOG.md`, `docs/backend/CHANGELOG.md`, `docs/backend/IMPLEMENTATION_INDEX.md`, `docs/backend/PHASE_3_SUMMARY.md`.

--- a/docs/backend/CHANGELOG.md
+++ b/docs/backend/CHANGELOG.md
@@ -3197,3 +3197,9 @@ Each entry is tied to a step from the implementation index.
 - `src/pages/dashboard/AnalyticsPage.tsx`
 - `docs/backend/PHASE_3_SUMMARY.md`
 - `docs/backend/STEP_3_16_COMMAND.md`
+
+## [Fix 2026-07-20] – Reading card metadata
+
+### 🟥 Fixes
+- Updated `ReadingReceiptCard` to show pump name with nozzle number and the attendant name.
+- Documented in `STEP_fix_20260720_COMMAND.md`.

--- a/docs/backend/IMPLEMENTATION_INDEX.md
+++ b/docs/backend/IMPLEMENTATION_INDEX.md
@@ -286,3 +286,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-19 | Lint cleanup and local DB docs | ✅ Done | `eslint.config.js`, `src/hooks/useApi.ts` | `docs/STEP_fix_20260719_COMMAND.md` |
 | fix | 2026-07-15 | Sales list station data | ✅ Done | `src/services/sales.service.ts`, `src/api/sales.ts` | `docs/STEP_fix_20260715_COMMAND.md` |
 | fix | 2026-07-15 | Reading meta fields | ✅ Done | `src/services/nozzleReading.service.ts`, `src/api/api-contract.ts`, `src/api/services/readingsService.ts` | `docs/STEP_fix_20260715_COMMAND.md` |
+| fix | 2026-07-20 | Reading card metadata | ✅ Done | `src/components/readings/ReadingReceiptCard.tsx` | `docs/STEP_fix_20260720_COMMAND.md` |

--- a/docs/backend/PHASE_3_SUMMARY.md
+++ b/docs/backend/PHASE_3_SUMMARY.md
@@ -503,3 +503,13 @@ Integrated latest fuel prices widget on the Owner dashboard and fixed missing fi
 **Validation Performed:**
 - Verified charts load data via analytics hooks
 - Tested station selector and ranking filters manually
+
+### 🛠️ Fix 2026-07-20 – Reading card metadata
+
+**Status:** ✅ Done
+**Files:** `src/components/readings/ReadingReceiptCard.tsx`
+
+**Overview:**
+- Daily log cards now show pump name together with the nozzle number.
+- Attendant name appears under the station title for clarity.
+- Documented in `STEP_fix_20260720_COMMAND.md`.

--- a/src/components/readings/ReadingReceiptCard.tsx
+++ b/src/components/readings/ReadingReceiptCard.tsx
@@ -77,9 +77,16 @@ export function ReadingReceiptCard({ reading, onView, onEdit }: ReadingReceiptCa
         <div className="flex items-start justify-between">
           <div>
             <h3 className="font-mono text-lg font-bold text-gray-900">
-              {reading.pumpName || `NOZZLE #${reading.nozzleNumber || 'N/A'}`}
+              {reading.pumpName
+                ? `${reading.pumpName} – Nozzle #${
+                    reading.nozzleNumber ?? 'N/A'
+                  }`
+                : `Nozzle #${reading.nozzleNumber ?? 'N/A'}`}
             </h3>
             <p className="text-sm text-gray-600">{reading.stationName}</p>
+            <p className="text-xs text-gray-500">
+              Recorded by: {reading.recordedBy || 'UNKNOWN'}
+            </p>
           </div>
           
           <Badge className={cn("text-xs font-semibold", statusConfig.color)}>
@@ -138,13 +145,8 @@ export function ReadingReceiptCard({ reading, onView, onEdit }: ReadingReceiptCa
         </div>
 
         {/* Footer */}
-        <div className="border-t border-dashed border-gray-300 pt-4 space-y-2">
-          <div className="text-xs text-gray-600 font-mono">
-            RECORDED BY: {reading.recordedBy || 'UNKNOWN'}
-          </div>
-          <div className="text-xs text-gray-600 font-mono">
-            {formatDateTime(reading.recordedAt)}
-          </div>
+        <div className="border-t border-dashed border-gray-300 pt-4 space-y-2 text-xs text-gray-600 font-mono">
+          <div>{formatDateTime(reading.recordedAt)}</div>
         </div>
 
         {/* Actions */}


### PR DESCRIPTION
## Summary
- show pump name and nozzle number together in `ReadingReceiptCard`
- display the recording attendant in the card header
- document metadata fix

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869a592e89c83209ed3ed9a68c8cff2