### PR TITLE
Fix all pumps listing on sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,3 +347,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Daily Reading Log cards now display pump name with nozzle number and show who recorded the reading.
 - Documented in `STEP_fix_20260720_COMMAND.md`.
+
+## [Fix 2026-07-21] - Pumps page shows all pumps
+
+### Changed
+- Removed station requirement in `PumpsPage` so `/dashboard/pumps` lists every pump.
+- Added "All Stations" option to the station dropdown and updated navigation handling.
+- Documented in `STEP_fix_20260721_COMMAND.md`.

--- a/docs/STEP_fix_20260721_COMMAND.md
+++ b/docs/STEP_fix_20260721_COMMAND.md
@@ -1,0 +1,12 @@
+# STEP_fix_20260721_COMMAND.md — Pumps page all pumps default
+
+Project Context Summary:
+FuelSync Hub's sidebar includes an **All Pumps** link pointing to `/dashboard/pumps`. The page currently returns an empty state asking to select a station. `usePumps` already loads all pumps when no stationId is provided (see `STEP_fix_20260715_COMMAND.md`), so the UI should list all pumps instead of blocking the user.
+
+Steps already implemented:
+- `src/hooks/api/usePumps.ts` fetches all pumps when `stationId` is undefined.
+- `src/pages/dashboard/PumpsPage.tsx` displays pump cards and create/delete dialogs.
+
+Task: Update `src/pages/dashboard/PumpsPage.tsx` to remove the early return for missing stationId, add an "All Stations" option to the dropdown and handle `stationId` changes so an empty value navigates to `/dashboard/pumps`. This will show all pumps by default.
+
+Required documentation updates: `CHANGELOG.md`, `docs/backend/CHANGELOG.md`, `docs/backend/IMPLEMENTATION_INDEX.md`, `docs/backend/PHASE_3_SUMMARY.md`.

--- a/docs/backend/CHANGELOG.md
+++ b/docs/backend/CHANGELOG.md
@@ -3203,3 +3203,10 @@ Each entry is tied to a step from the implementation index.
 ### 🟥 Fixes
 - Updated `ReadingReceiptCard` to show pump name with nozzle number and the attendant name.
 - Documented in `STEP_fix_20260720_COMMAND.md`.
+
+## [Fix 2026-07-21] – Pumps page default listing
+
+### 🟥 Fixes
+- `PumpsPage` no longer requires a station; selecting **All Pumps** now lists every pump.
+- Added an "All Stations" option to the dropdown filter.
+- Documented in `STEP_fix_20260721_COMMAND.md`.

--- a/docs/backend/IMPLEMENTATION_INDEX.md
+++ b/docs/backend/IMPLEMENTATION_INDEX.md
@@ -287,3 +287,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-15 | Sales list station data | ✅ Done | `src/services/sales.service.ts`, `src/api/sales.ts` | `docs/STEP_fix_20260715_COMMAND.md` |
 | fix | 2026-07-15 | Reading meta fields | ✅ Done | `src/services/nozzleReading.service.ts`, `src/api/api-contract.ts`, `src/api/services/readingsService.ts` | `docs/STEP_fix_20260715_COMMAND.md` |
 | fix | 2026-07-20 | Reading card metadata | ✅ Done | `src/components/readings/ReadingReceiptCard.tsx` | `docs/STEP_fix_20260720_COMMAND.md` |
+| fix | 2026-07-21 | Pumps page default listing | ✅ Done | `src/pages/dashboard/PumpsPage.tsx` | `docs/STEP_fix_20260721_COMMAND.md` |

--- a/docs/backend/PHASE_3_SUMMARY.md
+++ b/docs/backend/PHASE_3_SUMMARY.md
@@ -513,3 +513,13 @@ Integrated latest fuel prices widget on the Owner dashboard and fixed missing fi
 - Daily log cards now show pump name together with the nozzle number.
 - Attendant name appears under the station title for clarity.
 - Documented in `STEP_fix_20260720_COMMAND.md`.
+
+### 🛠️ Fix 2026-07-21 – Pumps page default listing
+
+**Status:** ✅ Done
+**Files:** `src/pages/dashboard/PumpsPage.tsx`
+
+**Overview:**
+- Removed early return so the pumps page lists all pumps when opened from the sidebar.
+- Dropdown now includes an **All Stations** option and clears the query when selected.
+- Documented in `STEP_fix_20260721_COMMAND.md`.

--- a/src/pages/dashboard/PumpsPage.tsx
+++ b/src/pages/dashboard/PumpsPage.tsx
@@ -33,7 +33,10 @@ export default function PumpsPage() {
   // Check for stationId in query params if not in route params
   const queryParams = new URLSearchParams(location.search);
   const stationIdFromQuery = queryParams.get('stationId');
-  const effectiveStationId = stationId || stationIdFromQuery || selectedStationId;
+  const effectiveStationId =
+    stationId ||
+    (stationIdFromQuery && stationIdFromQuery !== 'all' ? stationIdFromQuery : undefined) ||
+    (selectedStationId || undefined);
 
   const form = useForm({
     defaultValues: {
@@ -90,8 +93,13 @@ export default function PumpsPage() {
 
   // Handle station change
   const handleStationChange = (value: string) => {
-    setSelectedStationId(value);
-    navigate(`/dashboard/pumps?stationId=${value}`);
+    if (!value || value === 'all') {
+      setSelectedStationId('');
+      navigate('/dashboard/pumps');
+    } else {
+      setSelectedStationId(value);
+      navigate(`/dashboard/pumps?stationId=${value}`);
+    }
   };
 
   // Handle view nozzles navigation
@@ -136,41 +144,6 @@ export default function PumpsPage() {
 
   const isLoading = stationsLoading || pumpsLoading;
 
-  // If no station is selected, show station selector
-  if (!effectiveStationId) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 p-4">
-        <div className="container mx-auto space-y-8">
-          <div className="flex items-center gap-4 pt-2">
-            <Button 
-              variant="ghost" 
-              size="sm" 
-              onClick={handleBackToStations}
-              className="p-2 hover:bg-white/60 rounded-full"
-            >
-              <ArrowLeft className="h-5 w-5 text-slate-600" />
-            </Button>
-            <div>
-              <h1 className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-                Fuel Dispensers
-              </h1>
-              <p className="text-slate-600 mt-1">Select a station to manage fuel pumps</p>
-            </div>
-          </div>
-          
-          <EmptyState
-            icon={<Building2 className="h-12 w-12 text-blue-500" />}
-            title="Select a Station"
-            description="Choose a station to view and manage its fuel dispensers"
-            action={{
-              label: "View All Stations",
-              onClick: handleBackToStations
-            }}
-          />
-        </div>
-      </div>
-    );
-  }
 
   if (isLoading) {
     return (
@@ -200,11 +173,12 @@ export default function PumpsPage() {
               </h1>
               <div className="flex items-center gap-3 mt-2">
                 <Building2 className="h-5 w-5 text-slate-500" />
-                <Select value={effectiveStationId} onValueChange={handleStationChange}>
+                <Select value={effectiveStationId ?? 'all'} onValueChange={handleStationChange}>
                   <SelectTrigger className="w-[250px] bg-white/80 border-2 border-white shadow-lg">
                     <SelectValue placeholder="Select station" />
                   </SelectTrigger>
                   <SelectContent className="bg-white border-2 shadow-xl">
+                    <SelectItem value="all">All Stations</SelectItem>
                     {stations.map((station) => (
                       <SelectItem key={station.id} value={station.id}>
                         {station.name}


### PR DESCRIPTION
## Summary
- show all pumps when visiting /dashboard/pumps
- allow selecting **All Stations** in pumps page
- document pumps page fix

## Testing
- `npm run lint`
- `npm test` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a746ba0483208290a92226fccc40