### PR TITLE
Implement fuel price range enforcement

### DIFF
--- a/backend/src/services/fuelPrice.service.ts
+++ b/backend/src/services/fuelPrice.service.ts
@@ -7,10 +7,39 @@ export async function createFuelPrice(db: Pool, tenantId: string, input: FuelPri
   const client = await db.connect();
   try {
     await client.query('BEGIN');
+    const validFrom = input.validFrom || new Date();
+
+    const overlapRes = await client.query<{ id: string; effective_to: Date | null }>(
+      `SELECT id, effective_to, valid_from
+         FROM public.fuel_prices
+        WHERE station_id = $1
+          AND fuel_type = $2
+          AND tenant_id = $3
+          AND (effective_to IS NULL OR effective_to >= $4)`,
+      [input.stationId, input.fuelType, tenantId, validFrom]
+    );
+
+    let openId: string | null = null;
+    for (const row of overlapRes.rows) {
+      if (row.effective_to === null) {
+        if (openId) {
+          throw new Error('Multiple open fuel price ranges found');
+        }
+        openId = row.id;
+      } else {
+        throw new Error('Overlapping fuel price range exists');
+      }
+    }
+
+    if (openId) {
+      const end = new Date(validFrom.getTime() - 1000);
+      await client.query('UPDATE public.fuel_prices SET effective_to = $1, updated_at = NOW() WHERE id = $2', [end, openId]);
+    }
+
     const res = await client.query<{ id: string }>(
       `INSERT INTO public.fuel_prices (id, tenant_id, station_id, fuel_type, price, valid_from, updated_at)
        VALUES ($1,$2,$3,$4,$5,$6,NOW()) RETURNING id`,
-      [randomUUID(), tenantId, input.stationId, input.fuelType, input.price, input.validFrom || new Date()]
+      [randomUUID(), tenantId, input.stationId, input.fuelType, input.price, validFrom]
     );
     await client.query('COMMIT');
     return res.rows[0].id;


### PR DESCRIPTION
## Summary
- prevent overlapping fuel price ranges when creating new prices
- close open ranges before inserting new price records

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4b5f569883209fcc59dc63a5c503