### PR TITLE
Fix: fuel price range override

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -3055,3 +3055,26 @@ Each entry is tied to a step from the implementation index.
 * `src/controllers/dashboard.controller.ts`
 * `tests/dashboard.controller.test.ts`
 * `docs/STEP_fix_20260717_COMMAND.md`
+
+## [Fix 2026-07-18] – Fuel price effective dates
+
+### 🟥 Fixes
+* `validFrom` in fuel price validation defaults to the current timestamp.
+* `effectiveTo` can now be provided and must be later than `validFrom`.
+
+### Files
+* `backend/src/validators/fuelPrice.validator.ts`
+* `backend/src/controllers/fuelPrice.controller.ts`
+* `backend/src/services/fuelPrice.service.ts`
+* `src/api/api-contract.ts`
+* `docs/STEP_fix_20260718_COMMAND.md`
+
+## [Fix 2026-07-19] – Fuel price range override
+
+### 🟥 Fixes
+* Inserting a new price now closes the previous active range by setting its `effective_to` to the new price's `valid_from`.
+
+### Files
+* `backend/src/controllers/fuelPrice.controller.ts`
+* `backend/src/services/fuelPrice.service.ts`
+* `docs/STEP_fix_20260719_COMMAND.md`

--- a/backend/docs/IMPLEMENTATION_INDEX.md
+++ b/backend/docs/IMPLEMENTATION_INDEX.md
@@ -256,3 +256,5 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 3     | 3.16 | Owner analytics dashboard | ✅ Done | `src/pages/dashboard/AnalyticsPage.tsx` | `PHASE_3_SUMMARY.md#step-3.16` |
 | fix | 2026-07-16 | Azure deployment docs | ✅ Done | `docs/AZURE_DEPLOYMENT_GUIDE.md`, `docs/AZURE_DEV_SETUP.md`, `README.md` | `docs/STEP_fix_20260716_COMMAND.md` |
 | fix | 2026-07-17 | Dashboard station access | ✅ Done | `src/controllers/dashboard.controller.ts`, `tests/dashboard.controller.test.ts` | `docs/STEP_fix_20260717_COMMAND.md` |
+| fix | 2026-07-18 | Fuel price effective dates | ✅ Done | `backend/src/validators/fuelPrice.validator.ts`, `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts`, `src/api/api-contract.ts` | `docs/STEP_fix_20260718_COMMAND.md` |
+| fix | 2026-07-19 | Fuel price range override | ✅ Done | `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts` | `docs/STEP_fix_20260719_COMMAND.md` |

--- a/backend/docs/PHASE_2_SUMMARY.md
+++ b/backend/docs/PHASE_2_SUMMARY.md
@@ -1358,3 +1358,18 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Added `user_stations` check to all dashboard endpoints with `stationId`.
 * Handlers return a 403 response when the user lacks access.
 * Added unit tests for the new validation logic.
+
+### 🛠️ Fix 2026-07-18 – Fuel price effective dates
+**Status:** ✅ Done
+**Files:** `backend/src/validators/fuelPrice.validator.ts`, `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts`, `src/api/api-contract.ts`, `docs/STEP_fix_20260718_COMMAND.md`
+
+**Overview:**
+* `validFrom` in fuel price creation is now optional and defaults to the current timestamp.
+* `effectiveTo` may be supplied and must be later than `validFrom`.
+
+### 🛠️ Fix 2026-07-19 – Fuel price range override
+**Status:** ✅ Done
+**Files:** `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts`, `docs/STEP_fix_20260719_COMMAND.md`
+
+**Overview:**
+* When creating a new fuel price, any open range for the same station and fuel type is automatically closed by setting its `effective_to` to the new `valid_from`.

--- a/backend/docs/STEP_fix_20260718.md
+++ b/backend/docs/STEP_fix_20260718.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260718.md — Fuel price date options
+
+## Project Context Summary
+Fuel price creation previously required a `validFrom` timestamp. Clients sometimes omit this, expecting the backend to apply the current date. The schema also includes an optional `effective_to` field that was not exposed.
+
+## Steps Already Implemented
+All fixes up to `2026-07-17` are present including dashboard access validation.
+
+## What We Built
+- `FuelPriceInput` now allows `validFrom` to be omitted and added an optional `effectiveTo` property.
+- `validateCreateFuelPrice` assigns the current date when `validFrom` is missing and ensures `effectiveTo` is later.
+- Controllers and services pass through the new field and API contract types were updated.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260718_COMMAND.md`

--- a/backend/docs/STEP_fix_20260718_COMMAND.md
+++ b/backend/docs/STEP_fix_20260718_COMMAND.md
@@ -1,0 +1,19 @@
+# STEP_fix_20260718_COMMAND.md
+
+## Project Context Summary
+Fuel price validation currently requires `validFrom` but API clients expect it to default to the current date. The database also supports an optional `effective_to` column but the validator ignores it.
+
+## Steps Already Implemented
+Fixes through `2026-07-17` include dashboard access checks and Azure docs.
+
+## What to Build Now
+- Update `backend/src/validators/fuelPrice.validator.ts` so `validFrom` is optional and defaults to `new Date()`.
+- Parse an optional `effectiveTo` and require it be later than `validFrom` when present.
+- Propagate these fields in controllers, services and shared API types.
+- Document the change in the changelog, implementation index and phase summary.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260718_COMMAND.md`

--- a/backend/docs/STEP_fix_20260719.md
+++ b/backend/docs/STEP_fix_20260719.md
@@ -1,0 +1,19 @@
+# STEP_fix_20260719.md — Close previous price ranges
+
+## Project Context Summary
+Fuel price creation now accepts optional `effectiveTo` but open ranges were left
+untouched when new prices were created.
+
+## Steps Already Implemented
+All fixes up to `2026-07-18` including date validations.
+
+## What We Built
+- Creation handlers update any open price for the same station and fuel type by
+  setting its `effective_to` to the new price's `valid_from`.
+- Both Prisma controller and service function have the override logic.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260719_COMMAND.md`

--- a/backend/docs/STEP_fix_20260719_COMMAND.md
+++ b/backend/docs/STEP_fix_20260719_COMMAND.md
@@ -1,0 +1,22 @@
+# STEP_fix_20260719_COMMAND.md
+
+## Project Context Summary
+The previous fix added optional `validFrom` and `effectiveTo` for fuel prices. However
+existing prices were not automatically closed when inserting a new price, causing
+overlapping ranges.
+
+## Steps Already Implemented
+Fix through `2026-07-18` includes fuel price effective dates support.
+
+## What to Build Now
+- Update fuel price creation logic so a new price closes any open range for the
+  same station and fuel type by setting `effective_to` of the previous row to the
+  new `valid_from`.
+- Apply this in both the Prisma controller and the raw service implementation.
+- Document the change in the changelog, phase summary and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260719_COMMAND.md`

--- a/src/api/api-contract.ts
+++ b/src/api/api-contract.ts
@@ -296,7 +296,7 @@ export interface FuelPrice {
   fuelType: 'petrol' | 'diesel' | 'premium' | 'cng' | 'lpg';
   price: number;
   validFrom: string;
-  validTo?: string;
+  effectiveTo?: string;
   isActive: boolean;
   createdAt: string;
   updatedAt?: string;
@@ -308,13 +308,13 @@ export interface CreateFuelPriceRequest {
   fuelType: 'petrol' | 'diesel' | 'premium' | 'cng' | 'lpg';
   price: number;
   validFrom?: string;
-  validTo?: string;
+  effectiveTo?: string;
 }
 
 export interface UpdateFuelPriceRequest {
   price?: number;
   validFrom?: string;
-  validTo?: string;
+  effectiveTo?: string;
   isActive?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- close previous fuel price range when inserting a new price
- document fix in changelog and phase summary

## Testing
- `npm --prefix backend run build` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4d7da2e08320966d9dba3b519be3