### PR TITLE
Fix attendant dashboard hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,3 +361,9 @@ All notable changes to this project will be documented in this file.
 - Deleted `docs/architecture/BACKEND_BRAIN.md` which duplicated `docs/backend_brain.md`.
 - Updated architecture README link.
 - Documented in `STEP_fix_20260722_COMMAND.md`.
+
+## [Fix 2026-07-23] - Attendant pages use proper APIs
+
+### Changed
+- Attendant dashboard and related pages now call `/attendant/*` endpoints when logged in as an attendant.
+- Documented in `STEP_fix_20260723_COMMAND.md`.

--- a/backend/docs/IMPLEMENTATION_INDEX.md
+++ b/backend/docs/IMPLEMENTATION_INDEX.md
@@ -258,3 +258,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-17 | Dashboard station access | ✅ Done | `src/controllers/dashboard.controller.ts`, `tests/dashboard.controller.test.ts` | `docs/STEP_fix_20260717_COMMAND.md` |
 | fix | 2026-07-18 | Fuel price effective dates | ✅ Done | `backend/src/validators/fuelPrice.validator.ts`, `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts`, `src/api/api-contract.ts` | `docs/STEP_fix_20260718_COMMAND.md` |
 | fix | 2026-07-19 | Fuel price range override | ✅ Done | `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts` | `docs/STEP_fix_20260719_COMMAND.md` |
+| fix | 2026-07-23 | Attendant pages use role APIs | ✅ Done | `src/pages/dashboard/*` | `docs/STEP_fix_20260723_COMMAND.md` |

--- a/docs/STEP_fix_20260723_COMMAND.md
+++ b/docs/STEP_fix_20260723_COMMAND.md
@@ -1,0 +1,14 @@
+# STEP_fix_20260723_COMMAND.md — Attendant pages use role APIs
+
+Project Context Summary:
+The frontend uses generic hooks like `useStations`, `usePumps` and `useCreditors` that call owner/manager routes. Attendant users hit 403 errors when loading dashboard or cash report pages because these routes require higher roles. Hooks for attendant specific APIs already exist in `src/hooks/api/useAttendant.ts` but are unused.
+
+Steps already implemented:
+- Attendant role routes exist in backend and contract services.
+- Previous fix 2026-07-22 cleaned docs.
+
+Task:
+Update attendant-facing pages (`AttendantDashboardPage.tsx`, `CashReportPage.tsx`, `CashReportsListPage.tsx`, `NewReadingPage.tsx`) to fetch stations, pumps, nozzles and creditors via attendant hooks when the logged in user role is `attendant`. Keep existing behaviour for owners/managers.
+Add brief entry to `CHANGELOG.md`, `docs/backend/CHANGELOG.md` and update `docs/backend/PHASE_3_SUMMARY.md`.
+
+Required documentation updates: CHANGELOG.md, docs/backend/CHANGELOG.md, docs/backend/PHASE_3_SUMMARY.md, docs/backend/IMPLEMENTATION_INDEX.md.

--- a/docs/backend/CHANGELOG.md
+++ b/docs/backend/CHANGELOG.md
@@ -3217,3 +3217,9 @@ Each entry is tied to a step from the implementation index.
 - Deleted duplicate architecture file `docs/architecture/BACKEND_BRAIN.md`.
 - Updated architecture README link to `backend_brain.md`.
 - Documented in `STEP_fix_20260722_COMMAND.md`.
+
+## [Fix 2026-07-23] – Attendant role endpoints
+
+### 🟥 Fixes
+- Updated frontend pages to use attendant-specific hooks when role is attendant.
+- Documented in `STEP_fix_20260723_COMMAND.md`.

--- a/docs/backend/IMPLEMENTATION_INDEX.md
+++ b/docs/backend/IMPLEMENTATION_INDEX.md
@@ -289,3 +289,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-20 | Reading card metadata | ✅ Done | `src/components/readings/ReadingReceiptCard.tsx` | `docs/STEP_fix_20260720_COMMAND.md` |
 | fix | 2026-07-21 | Pumps page default listing | ✅ Done | `src/pages/dashboard/PumpsPage.tsx` | `docs/STEP_fix_20260721_COMMAND.md` |
 | fix | 2026-07-22 | Remove duplicate backend brain doc | ✅ Done | `docs/architecture/README.md` | `docs/STEP_fix_20260722_COMMAND.md` |
+| fix | 2026-07-23 | Attendant pages use role APIs | ✅ Done | `src/pages/dashboard/*` | `docs/STEP_fix_20260723_COMMAND.md` |

--- a/docs/backend/PHASE_3_SUMMARY.md
+++ b/docs/backend/PHASE_3_SUMMARY.md
@@ -533,3 +533,13 @@ Integrated latest fuel prices widget on the Owner dashboard and fixed missing fi
 - Deleted duplicated `BACKEND_BRAIN.md` from the architecture docs.
 - Updated README link to point to `../backend_brain.md`.
 - Documented in `STEP_fix_20260722_COMMAND.md`.
+
+### 🛠️ Fix 2026-07-23 – Attendant role API usage
+
+**Status:** ✅ Done
+**Files:** `src/pages/dashboard/AttendantDashboardPage.tsx`, `src/pages/dashboard/CashReportPage.tsx`, `src/pages/dashboard/CashReportsListPage.tsx`, `src/pages/dashboard/NewReadingPage.tsx`
+
+**Overview:**
+- Pages now load stations, pumps, nozzles and creditors via `/attendant/*` endpoints when the logged user is an attendant.
+- Maintains existing behaviour for owners and managers.
+- Documented in `STEP_fix_20260723_COMMAND.md`.

--- a/src/pages/dashboard/AttendantDashboardPage.tsx
+++ b/src/pages/dashboard/AttendantDashboardPage.tsx
@@ -8,6 +8,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useStations } from '@/hooks/api/useStations';
+import { useAttendantStations } from '@/hooks/api/useAttendant';
+import { useAuth } from '@/contexts/AuthContext';
 import { useReadings } from '@/hooks/api/useReadings';
 import { useFuelPrices } from '@/hooks/api/useFuelPrices';
 import { format } from 'date-fns';
@@ -15,11 +17,16 @@ import { Loader2, FileText, Fuel, CreditCard, DollarSign } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 export default function AttendantDashboardPage() {
+  const { user } = useAuth();
+  const isAttendant = user?.role === 'attendant';
   const [selectedDate, setSelectedDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [selectedStationId, setSelectedStationId] = useState<string | undefined>();
   
-  // Fetch stations
-  const { data: stations = [], isLoading: stationsLoading } = useStations();
+  // Fetch stations using role appropriate endpoint
+  const {
+    data: stations = [],
+    isLoading: stationsLoading,
+  } = isAttendant ? useAttendantStations() : useStations();
   
   // Set default station if not selected
   if (!selectedStationId && stations.length > 0 && !stationsLoading) {

--- a/src/pages/dashboard/CashReportPage.tsx
+++ b/src/pages/dashboard/CashReportPage.tsx
@@ -13,13 +13,20 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useToast } from '@/hooks/use-toast';
 import { useStations } from '@/hooks/api/useStations';
 import { useCreditors } from '@/hooks/api/useCreditors';
-import { useCreateCashReport } from '@/hooks/useAttendant';
+import {
+  useAttendantStations,
+  useAttendantCreditors,
+  useCreateCashReport,
+} from '@/hooks/api/useAttendant';
+import { useAuth } from '@/contexts/AuthContext';
 import { format } from 'date-fns';
 import { ArrowLeft, Plus, Trash, DollarSign, CreditCard, Loader2 } from 'lucide-react';
 
 export default function CashReportPage() {
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { user } = useAuth();
+  const isAttendant = user?.role === 'attendant';
   const today = format(new Date(), 'yyyy-MM-dd');
   
   // State
@@ -30,10 +37,18 @@ export default function CashReportPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   
   // Fetch stations
-  const { data: stations = [], isLoading: stationsLoading } = useStations();
-  
+  const {
+    data: stations = [],
+    isLoading: stationsLoading,
+  } = isAttendant ? useAttendantStations() : useStations();
+
   // Fetch creditors for selected station
-  const { data: creditors = [], isLoading: creditorsLoading } = useCreditors(selectedStationId);
+  const {
+    data: creditors = [],
+    isLoading: creditorsLoading,
+  } = isAttendant
+    ? useAttendantCreditors(selectedStationId)
+    : useCreditors(selectedStationId);
   
   // Submit cash report mutation
   const submitCashReport = useCreateCashReport();

--- a/src/pages/dashboard/CashReportsListPage.tsx
+++ b/src/pages/dashboard/CashReportsListPage.tsx
@@ -9,6 +9,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { useStations } from '@/hooks/api/useStations';
 import { useCashReports } from '@/hooks/useAttendant';
+import { useAttendantStations } from '@/hooks/api/useAttendant';
+import { useAuth } from '@/contexts/AuthContext';
 import { format } from 'date-fns';
 import { ArrowLeft, RefreshCw, Loader2, DollarSign } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -16,9 +18,14 @@ import { Badge } from '@/components/ui/badge';
 export default function CashReportsListPage() {
   const navigate = useNavigate();
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const { user } = useAuth();
+  const isAttendant = user?.role === 'attendant';
   
   // Fetch stations
-  const { data: stations = [], isLoading: stationsLoading } = useStations();
+  const {
+    data: stations = [],
+    isLoading: stationsLoading,
+  } = isAttendant ? useAttendantStations() : useStations();
   
   // Fetch cash reports - no parameters as per API spec
   const { 

--- a/src/pages/dashboard/NewReadingPage.tsx
+++ b/src/pages/dashboard/NewReadingPage.tsx
@@ -15,6 +15,12 @@ import { ArrowLeft, Loader2, AlertCircle, CheckCircle } from 'lucide-react';
 import { useStations } from '@/hooks/api/useStations';
 import { usePumps } from '@/hooks/api/usePumps';
 import { useNozzles } from '@/hooks/api/useNozzles';
+import {
+  useAttendantStations,
+  useAttendantPumps,
+  useAttendantNozzles,
+} from '@/hooks/api/useAttendant';
+import { useAuth } from '@/contexts/AuthContext';
 import { useCreateReading, useLatestReading } from '@/hooks/api/useReadings';
 import { useFuelPrices } from '@/hooks/api/useFuelPrices';
 import { useToast } from '@/hooks/use-toast';
@@ -23,6 +29,8 @@ export default function NewReadingPage() {
   const navigate = useNavigate();
   const { nozzleId } = useParams();
   const { toast } = useToast();
+  const { user } = useAuth();
+  const isAttendant = user?.role === 'attendant';
   
   // Form state
   const [selectedStationId, setSelectedStationId] = useState('');
@@ -34,9 +42,18 @@ export default function NewReadingPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   
   // Data fetching
-  const { data: stations = [], isLoading: stationsLoading } = useStations();
-  const { data: pumps = [], isLoading: pumpsLoading } = usePumps(selectedStationId);
-  const { data: nozzles = [], isLoading: nozzlesLoading } = useNozzles(selectedPumpId);
+  const {
+    data: stations = [],
+    isLoading: stationsLoading,
+  } = isAttendant ? useAttendantStations() : useStations();
+  const {
+    data: pumps = [],
+    isLoading: pumpsLoading,
+  } = isAttendant ? useAttendantPumps(selectedStationId) : usePumps(selectedStationId);
+  const {
+    data: nozzles = [],
+    isLoading: nozzlesLoading,
+  } = isAttendant ? useAttendantNozzles(selectedPumpId) : useNozzles(selectedPumpId);
   const { data: latestReading, isLoading: latestReadingLoading } = useLatestReading(selectedNozzleId);
   const { data: fuelPrices = [] } = useFuelPrices(selectedStationId);
   const createReading = useCreateReading();


### PR DESCRIPTION
## Summary
- use attendant-specific API hooks when user role is `attendant`
- document attendant role hook update

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a534cf7208320aed97ae33077885f