### PR TITLE
Fix mobile hamburger menu for admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,3 +371,15 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Attendant dashboard and related pages now call `/attendant/*` endpoints when logged in as an attendant.
 - Documented in `STEP_fix_20260723_COMMAND.md`.
+
+## [Fix 2026-07-24] - Mobile sidebar toggle
+
+### Fixed
+- Hamburger menu in header now opens the sidebar on mobile by hoisting sidebar state to `DashboardLayout`.
+- Documented in `STEP_fix_20260724_COMMAND.md`.
+
+## [Fix 2026-07-25] - SuperAdmin sidebar toggle
+
+### Fixed
+- Header now falls back to `useSidebar` when no `onMobileMenuClick` prop is supplied, enabling the hamburger menu for SuperAdmin pages.
+- Documented in `STEP_fix_20260725_COMMAND.md`.

--- a/backend/docs/IMPLEMENTATION_INDEX.md
+++ b/backend/docs/IMPLEMENTATION_INDEX.md
@@ -260,3 +260,5 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-19 | Fuel price range override | ✅ Done | `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts` | `docs/STEP_fix_20260719_COMMAND.md` |
 | fix | 2026-07-23 | Attendant pages use role APIs | ✅ Done | `src/pages/dashboard/*` | `docs/STEP_fix_20260723_COMMAND.md` |
 | fix | 2026-07-22 | Fuel price service tests | ✅ Done | `backend/tests/fuelPrice.service.test.ts` | `docs/STEP_fix_20260722_COMMAND.md` |
+| fix | 2026-07-24 | Mobile sidebar toggle | ✅ Done | `src/components/layout/*` | `docs/STEP_fix_20260724_COMMAND.md` |
+| fix | 2026-07-25 | SuperAdmin sidebar toggle | ✅ Done | `src/components/layout/Header.tsx` | `docs/STEP_fix_20260725_COMMAND.md` |

--- a/docs/FRONTEND_CHANGELOG.md
+++ b/docs/FRONTEND_CHANGELOG.md
@@ -498,3 +498,12 @@
 ## Previous Changes
 
 [Previous changelog entries...]
+## 2026-07-24: Mobile sidebar toggle fix
+
+### Fixed
+- Header hamburger button now toggles the sidebar on mobile screens.
+
+## 2026-07-25: SuperAdmin sidebar toggle fix
+
+### Fixed
+- Hamburger menu now works for SuperAdmin pages by falling back to `useSidebar` when no click handler is provided.

--- a/docs/STEP_fix_20260724_COMMAND.md
+++ b/docs/STEP_fix_20260724_COMMAND.md
@@ -1,0 +1,14 @@
+# STEP_fix_20260724_COMMAND.md — Mobile sidebar toggle fix
+
+Project Context Summary:
+The mobile dashboard layout shows a hamburger button in the header but clicking it does not open the sidebar. The sidebar component maintains its own state internally, so the header button is disconnected.
+
+Steps already implemented:
+- Attendant pages were updated to use role APIs (STEP_fix_20260723_COMMAND.md).
+- Previous fixes include pumps page default listing and fuel price service tests.
+
+Task:
+Allow the header hamburger button to toggle the mobile sidebar by hoisting the sidebar open state to `DashboardLayout`. Pass `open` and `onOpenChange` props to `Sidebar`, and add an `onMobileMenuClick` callback prop to `Header` which opens the sidebar. Remove the unused local state in `Header`.
+Update CHANGELOG.md, docs/FRONTEND_CHANGELOG.md, docs/backend/IMPLEMENTATION_INDEX.md, backend/docs/IMPLEMENTATION_INDEX.md and docs/backend/PHASE_3_SUMMARY.md.
+
+Required documentation updates: CHANGELOG.md, docs/FRONTEND_CHANGELOG.md, docs/backend/IMPLEMENTATION_INDEX.md, backend/docs/IMPLEMENTATION_INDEX.md, docs/backend/PHASE_3_SUMMARY.md.

--- a/docs/STEP_fix_20260725_COMMAND.md
+++ b/docs/STEP_fix_20260725_COMMAND.md
@@ -1,0 +1,14 @@
+# STEP_fix_20260725_COMMAND.md — SuperAdmin sidebar toggle
+
+Project Context Summary:
+The mobile hamburger menu in the Header now controls the Sidebar state via props. However, on SuperAdmin pages the Header is nested in `SidebarProvider` which exposes a `toggleSidebar` function. Because the Header expects an `onMobileMenuClick` prop, the button does nothing for superadmin users.
+
+Steps already implemented:
+- Sidebar state hoisted to DashboardLayout and Header accepts `onMobileMenuClick` (STEP_fix_20260724_COMMAND.md).
+- Attendant pages use proper role APIs (STEP_fix_20260723_COMMAND.md).
+
+Task:
+Update `Header` so that when no `onMobileMenuClick` prop is provided, it tries to use `useSidebar().toggleSidebar` if available. This enables the hamburger menu for SuperAdminLayout without requiring additional props.
+Update CHANGELOG.md, docs/FRONTEND_CHANGELOG.md, docs/backend/IMPLEMENTATION_INDEX.md, backend/docs/IMPLEMENTATION_INDEX.md and docs/backend/PHASE_3_SUMMARY.md.
+
+Required documentation updates: CHANGELOG.md, docs/FRONTEND_CHANGELOG.md, docs/backend/IMPLEMENTATION_INDEX.md, backend/docs/IMPLEMENTATION_INDEX.md, docs/backend/PHASE_3_SUMMARY.md.

--- a/docs/backend/IMPLEMENTATION_INDEX.md
+++ b/docs/backend/IMPLEMENTATION_INDEX.md
@@ -291,3 +291,5 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-22 | Fuel price service tests | ✅ Done | `backend/tests/fuelPrice.service.test.ts` | `docs/STEP_fix_20260722_COMMAND.md` |
 | fix | 2026-07-22 | Remove duplicate backend brain doc | ✅ Done | `docs/architecture/README.md` | `docs/STEP_fix_20260722_COMMAND.md` |
 | fix | 2026-07-23 | Attendant pages use role APIs | ✅ Done | `src/pages/dashboard/*` | `docs/STEP_fix_20260723_COMMAND.md` |
+| fix | 2026-07-24 | Mobile sidebar toggle | ✅ Done | `src/components/layout/*` | `docs/STEP_fix_20260724_COMMAND.md` |
+| fix | 2026-07-25 | SuperAdmin sidebar toggle | ✅ Done | `src/components/layout/Header.tsx` | `docs/STEP_fix_20260725_COMMAND.md` |

--- a/docs/backend/PHASE_3_SUMMARY.md
+++ b/docs/backend/PHASE_3_SUMMARY.md
@@ -543,3 +543,23 @@ Integrated latest fuel prices widget on the Owner dashboard and fixed missing fi
 - Pages now load stations, pumps, nozzles and creditors via `/attendant/*` endpoints when the logged user is an attendant.
 - Maintains existing behaviour for owners and managers.
 - Documented in `STEP_fix_20260723_COMMAND.md`.
+
+### 🛠️ Fix 2026-07-24 – Mobile sidebar toggle
+
+**Status:** ✅ Done
+**Files:** `src/components/layout/Header.tsx`, `src/components/layout/Sidebar.tsx`, `src/components/layout/DashboardLayout.tsx`
+
+**Overview:**
+- Hoisted sidebar open state to `DashboardLayout`.
+- Header hamburger button now opens the sidebar on mobile.
+- Documented in `STEP_fix_20260724_COMMAND.md`.
+
+### 🛠️ Fix 2026-07-25 – SuperAdmin sidebar toggle
+
+**Status:** ✅ Done
+**Files:** `src/components/layout/Header.tsx`
+
+**Overview:**
+- Header now toggles the `SidebarProvider` sidebar when no click handler is passed.
+- Ensures the hamburger menu works for SuperAdmin pages.
+- Documented in `STEP_fix_20260725_COMMAND.md`.

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -9,9 +9,9 @@ export function DashboardLayout() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
-      <Sidebar />
+      <Sidebar open={sidebarOpen} onOpenChange={setSidebarOpen} />
       <div className="lg:pl-72">
-        <Header />
+        <Header onMobileMenuClick={() => setSidebarOpen(true)} />
         <main className="py-6">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <Outlet />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,14 +13,24 @@ import {
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { useAuth } from '@/contexts/AuthContext';
 import { User, LogOut, Settings, Crown, Building2, UserCheck, Zap, Menu } from 'lucide-react';
+import { useSidebar } from '@/components/ui/sidebar';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useState } from 'react';
 
-export function Header() {
+export interface HeaderProps {
+  onMobileMenuClick?: () => void;
+}
+
+export function Header({ onMobileMenuClick }: HeaderProps) {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  let sidebarToggle: (() => void) | undefined;
+  try {
+    sidebarToggle = useSidebar().toggleSidebar;
+  } catch {
+    sidebarToggle = undefined;
+  }
+  const handleMobileMenuClick = onMobileMenuClick ?? sidebarToggle;
 
   // Get current page title based on route
   const getPageTitle = () => {
@@ -128,7 +138,7 @@ export function Header() {
             variant="ghost"
             size="icon"
             className="h-8 w-8 lg:hidden"
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            onClick={handleMobileMenuClick}
           >
             <Menu className="h-4 w-4" />
           </Button>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -260,8 +260,16 @@ function SidebarContent({ onItemClick }: SidebarContentProps) {
   );
 }
 
-export function Sidebar() {
-  const [open, setOpen] = useState(false);
+export interface SidebarProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function Sidebar({ open: openProp, onOpenChange }: SidebarProps = {}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const controlled = typeof openProp === 'boolean' && onOpenChange;
+  const open = controlled ? openProp : internalOpen;
+  const setOpen = controlled ? onOpenChange! : setInternalOpen;
   return (
     <>
       {/* Desktop Sidebar */}


### PR DESCRIPTION
## Summary
- handle mobile sidebar toggle inside `Header` when nested in `SidebarProvider`
- document superadmin sidebar fix in changelogs and summaries

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686a6b356ef08320aed007b343714bcb