### PR TITLE
Fix attendant dashboard API usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,3 +371,17 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Attendant dashboard and related pages now call `/attendant/*` endpoints when logged in as an attendant.
 - Documented in `STEP_fix_20260723_COMMAND.md`.
+
+## [Fix 2026-07-24] - Clarify attendant API limits
+
+### Changed
+- Updated `docs/journeys/ATTENDANT.md` to note missing reading and fuel price listing endpoints.
+- Added comment about stubbed attendance/shifts APIs.
+- Documented in `STEP_fix_20260724_COMMAND.md`.
+
+## [Fix 2026-07-25] - Skip restricted API calls for attendants
+
+### Changed
+- Dashboard and reading pages no longer request `/fuel-prices` or `/nozzle-readings` when logged in as an attendant.
+- Documentation updated to describe attendant capabilities.
+- Documented in `STEP_fix_20260725_COMMAND.md`.

--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -3078,3 +3078,25 @@ Each entry is tied to a step from the implementation index.
 * `backend/src/controllers/fuelPrice.controller.ts`
 * `backend/src/services/fuelPrice.service.ts`
 * `docs/STEP_fix_20260719_COMMAND.md`
+
+
+## [Fix 2026-07-23] – Attendant pages use role APIs
+
+### 🟥 Fixes
+* Switched station, pump, nozzle and creditor lookups to `/attendant/*` routes when role is `attendant`.
+* `AttendantDashboardPage`, `CashReportPage`, `CashReportsListPage` and `NewReadingPage` updated.
+* `docs/STEP_fix_20260723_COMMAND.md`
+
+## [Fix 2026-07-24] – Clarify attendant API limits
+
+### 🟦 Documentation
+* Updated `docs/journeys/ATTENDANT.md` with notes about missing reading and price listing APIs.
+* Added explanation of stubbed attendance/shifts endpoints.
+* `docs/STEP_fix_20260724_COMMAND.md`
+
+## [Fix 2026-07-25] – Disable restricted attendant requests
+
+### 🟥 Fixes
+* Attendant dashboard and new reading pages no longer hit owner-only endpoints.
+* Updated attendant journey documentation.
+* `docs/STEP_fix_20260725_COMMAND.md`

--- a/backend/docs/IMPLEMENTATION_INDEX.md
+++ b/backend/docs/IMPLEMENTATION_INDEX.md
@@ -259,4 +259,6 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-18 | Fuel price effective dates | ✅ Done | `backend/src/validators/fuelPrice.validator.ts`, `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts`, `src/api/api-contract.ts` | `docs/STEP_fix_20260718_COMMAND.md` |
 | fix | 2026-07-19 | Fuel price range override | ✅ Done | `backend/src/controllers/fuelPrice.controller.ts`, `backend/src/services/fuelPrice.service.ts` | `docs/STEP_fix_20260719_COMMAND.md` |
 | fix | 2026-07-23 | Attendant pages use role APIs | ✅ Done | `src/pages/dashboard/*` | `docs/STEP_fix_20260723_COMMAND.md` |
+| fix | 2026-07-24 | Clarify attendant API limits | ✅ Done | `docs/journeys/ATTENDANT.md` | `docs/STEP_fix_20260724_COMMAND.md` |
+| fix | 2026-07-25 | Skip restricted attendant API calls | ✅ Done | `src/pages/dashboard/AttendantDashboardPage.tsx`, `src/pages/dashboard/NewReadingPage.tsx` | `docs/STEP_fix_20260725_COMMAND.md` |
 | fix | 2026-07-22 | Fuel price service tests | ✅ Done | `backend/tests/fuelPrice.service.test.ts` | `docs/STEP_fix_20260722_COMMAND.md` |

--- a/docs/STEP_fix_20260724_COMMAND.md
+++ b/docs/STEP_fix_20260724_COMMAND.md
@@ -1,0 +1,16 @@
+# STEP_fix_20260724_COMMAND.md — Clarify attendant role access
+
+## Project Context Summary
+The frontend still issues requests to `/nozzle-readings` and `/fuel-prices` when an attendant is logged in. These endpoints are owner/manager only, resulting in `403` errors. Attendant specific routes exist but there is no listing API for readings or prices. The journey docs are outdated (last updated 2025-07-05) and miss these details.
+
+## Steps already implemented
+- Attendant endpoints for stations, pumps, nozzles, creditors and cash reports (`docs/journeys/ATTENDANT.md`).
+- Fix 2026-07-23 changed frontend pages to use attendant hooks for hierarchy data.
+
+## What to build now
+Update `docs/journeys/ATTENDANT.md` to clearly list the available endpoints and explicitly state that attendants cannot fetch `/fuel-prices` or list `/nozzle-readings`. Note the stubbed attendance/shifts APIs. This documents why 403 errors occur when generic hooks are used.
+
+## Required documentation updates
+- `docs/journeys/ATTENDANT.md` (updated)
+- `CHANGELOG.md` entry under Fix 2026-07-24
+- `backend/docs/IMPLEMENTATION_INDEX.md` new row

--- a/docs/STEP_fix_20260725_COMMAND.md
+++ b/docs/STEP_fix_20260725_COMMAND.md
@@ -1,0 +1,26 @@
+# STEP_fix_20260725_COMMAND.md — Skip restricted API calls for attendant
+
+## Project Context Summary
+Attendant users still see 403 errors because the dashboard and reading entry pages
+request `/fuel-prices` and `/nozzle-readings` listings which are owner/manager only.
+Previous fix routed hierarchy lookups through `/attendant/*`, but these pages
+still fetch restricted resources.
+
+## Steps already implemented
+- Attendant pages use attendant stations/pumps/nozzles hooks (`STEP_fix_20260723_COMMAND.md`).
+- Documentation clarifies lack of listing APIs (`STEP_fix_20260724_COMMAND.md`).
+
+## What to build now
+- Update `AttendantDashboardPage.tsx` and `NewReadingPage.tsx` to avoid calling
+  `/fuel-prices` and `/nozzle-readings` when role is `attendant`. Use React Query
+  with `enabled: false` so no network request occurs.
+- Adjust logic so attendants can still record readings without fuel price data.
+- Update `docs/journeys/ATTENDANT.md` to describe the available features and note
+  that the UI omits price and reading listings for attendants.
+
+## Required documentation updates
+- `CHANGELOG.md`
+- `backend/docs/CHANGELOG.md`
+- `backend/docs/IMPLEMENTATION_INDEX.md`
+- `docs/backend/PHASE_3_SUMMARY.md`
+- `docs/journeys/ATTENDANT.md`

--- a/docs/backend/PHASE_3_SUMMARY.md
+++ b/docs/backend/PHASE_3_SUMMARY.md
@@ -543,3 +543,21 @@ Integrated latest fuel prices widget on the Owner dashboard and fixed missing fi
 - Pages now load stations, pumps, nozzles and creditors via `/attendant/*` endpoints when the logged user is an attendant.
 - Maintains existing behaviour for owners and managers.
 - Documented in `STEP_fix_20260723_COMMAND.md`.
+
+### 🛠️ Fix 2026-07-24 – Clarify attendant API limits
+
+**Status:** ✅ Done
+**Files:** `docs/journeys/ATTENDANT.md`
+
+**Overview:**
+- Documented missing listing endpoints for attendants and stubbed attendance/shifts APIs.
+- See `STEP_fix_20260724_COMMAND.md`.
+
+### 🛠️ Fix 2026-07-25 – Skip restricted API calls
+
+**Status:** ✅ Done
+**Files:** `src/pages/dashboard/AttendantDashboardPage.tsx`, `src/pages/dashboard/NewReadingPage.tsx`
+
+**Overview:**
+- Dashboard and new reading pages no longer issue requests to `/fuel-prices` or `/nozzle-readings` when the logged user is an attendant.
+- Documentation updated accordingly (`STEP_fix_20260725_COMMAND.md`).

--- a/docs/journeys/ATTENDANT.md
+++ b/docs/journeys/ATTENDANT.md
@@ -1,6 +1,6 @@
 ---
 title: ATTENDANT Role Journey
-lastUpdated: 2025-07-05
+lastUpdated: 2026-07-25
 category: journeys
 ---
 
@@ -19,6 +19,12 @@ Attendants perform basic operations like recording nozzle readings and submittin
 - `PUT /api/v1/attendant/alerts/{id}/acknowledge`
 - Create nozzle reading: `POST /api/v1/nozzle-readings`
 - Check can create: `GET /api/v1/nozzle-readings/can-create/{nozzleId}`
+- (planned) `GET /attendance?date=YYYY-MM-DD` *(not implemented; returns empty array)*
+- (planned) `GET /shifts?date=YYYY-MM-DD` *(not implemented; returns empty array)*
+
+> **Note**: Attendants cannot call `GET /fuel-prices` or list existing `nozzle-readings`.
+> These routes are restricted to Owner/Manager roles. The frontend now skips these
+> requests entirely when an attendant is logged in.
 
 All require `Authorization` header and `x-tenant-id` matching the JWT claim.
 
@@ -27,7 +33,7 @@ JWTs expire in 1h; refresh via `/api/v1/auth/refresh`.
 
 ## Typical Flow
 1. Login and fetch assigned station list.
-2. Record nozzle readings during shift.
-3. Submit daily cash totals via cash report endpoint.
-4. Acknowledge any alerts.
-
+2. Retrieve pumps and nozzles for the selected station.
+3. Record nozzle readings during shift.
+4. Submit daily cash totals via cash report endpoint.
+5. Acknowledge any alerts.

--- a/src/pages/dashboard/AttendantDashboardPage.tsx
+++ b/src/pages/dashboard/AttendantDashboardPage.tsx
@@ -10,8 +10,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useStations } from '@/hooks/api/useStations';
 import { useAttendantStations } from '@/hooks/api/useAttendant';
 import { useAuth } from '@/contexts/AuthContext';
-import { useReadings } from '@/hooks/api/useReadings';
-import { useFuelPrices } from '@/hooks/api/useFuelPrices';
+import { useQuery } from '@tanstack/react-query';
+import { readingsService } from '@/api/services/readingsService';
+import { fuelPricesService } from '@/api/services/fuelPricesService';
 import { format } from 'date-fns';
 import { Loader2, FileText, Fuel, CreditCard, DollarSign } from 'lucide-react';
 import { Link } from 'react-router-dom';
@@ -33,11 +34,25 @@ export default function AttendantDashboardPage() {
     setSelectedStationId(stations[0].id);
   }
   
-  // Fetch readings for today
-  const { data: readings = [], isLoading: readingsLoading } = useReadings();
-  
-  // Fetch fuel prices
-  const { data: fuelPrices = [], isLoading: pricesLoading } = useFuelPrices(selectedStationId);
+  // Fetch readings for today (disabled for attendants)
+  const {
+    data: readings = [],
+    isLoading: readingsLoading,
+  } = useQuery({
+    queryKey: ['readings'],
+    queryFn: () => readingsService.getReadings(),
+    enabled: !isAttendant,
+  });
+
+  // Fetch fuel prices (owners/managers only)
+  const {
+    data: fuelPrices = [],
+    isLoading: pricesLoading,
+  } = useQuery({
+    queryKey: ['fuel-prices', selectedStationId],
+    queryFn: () => fuelPricesService.getFuelPrices(selectedStationId),
+    enabled: !isAttendant && !!selectedStationId,
+  });
   
   const isLoading = stationsLoading || readingsLoading || pricesLoading;
   


### PR DESCRIPTION
## Summary
- skip restricted fuel price and reading endpoints for attendants
- adjust attendant reading page validation
- update attendant journey doc and phase summary
- log change in docs and changelog

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686a5dfb1b6083209e42e7c78976b711